### PR TITLE
Added right-click context menu

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
-const CLIENT_ID = encodeURIComponent('e398a5b2c6eb42bfa305efab6caefc72'); // change this according to your Spotify OAuth Client ID
+const CLIENT_ID = encodeURIComponent('64fb35d3e3de4fecb0e0d60cd76dd006'); // change this according to your Spotify OAuth Client ID
 const EXTENSION_ID = 'hflkbdhappjboleecikmjbfnjhifdhhm'; // Change this according to your extension
 const RESPONSE_TYPE = encodeURIComponent('token');
-const REDIRECT_URI = encodeURIComponent('https://gfhecgoaelkeeippfcekipomkpfmdkjp.chromiumapp.org/');
+const REDIRECT_URI = encodeURIComponent('https://hflkbdhappjboleecikmjbfnjhifdhhm.chromiumapp.org/');
 const SHOW_DIALOG = encodeURIComponent('true');
 
 const SCOPE = encodeURIComponent("user-library-modify", 
@@ -81,6 +81,29 @@ function formatParams(params) {
         })
         .join("&")
 }
+
+function rightClickSearch(word){
+    console.log("Sending request..");
+    searchSpotify(word);
+    chrome.tabs.create({
+        url: chrome.extension.getURL('popup-signed-in.html'),
+        active: false
+    }, function(tab) {
+        // After the tab has been created, open a window to inject the tab
+        chrome.windows.create({
+            tabId: tab.id,
+            type: 'popup',
+            focused: true
+        });
+    });
+}
+
+// Add right-click functionality
+chrome.contextMenus.create({
+    title: "SPOT!",
+    contexts:["selection"],
+    onclick: rightClickSearch
+})
 
 // Search spotify function
 function searchSpotify(query) {

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
         "storage",
         "identity",
         "tabs",
+        "contextMenus",
         "https://api.spotify.com/"
     ]
 }


### PR DESCRIPTION
I've theoretically been able to add a context menu.

## You can now highlight a word and search with spot.

![Screenshot 2020-11-02 200356](https://user-images.githubusercontent.com/22739244/97880162-d3026d80-1d46-11eb-9c84-cb7972b2f7df.png)
![Screenshot 2020-11-02 200532](https://user-images.githubusercontent.com/22739244/97880173-d5fd5e00-1d46-11eb-950f-2510a307df92.png)


# Current issues:
- It simply opens the popup, doesn't really search
- Cannot open the actual popup.  **Prohibited by chrome**
- Please refer
https://stackoverflow.com/questions/13783500/context-menus-in-chrome-extensions